### PR TITLE
Add snappy PKGBUILD

### DIFF
--- a/mingw-w64-snappy/PKGBUILD
+++ b/mingw-w64-snappy/PKGBUILD
@@ -1,0 +1,65 @@
+# Forked from https://github.com/msys2/MINGW-packages/blob/31874fad09ae45f322aa6482a7e3ea20d84c436e/mingw-w64-snappy/PKGBUILD
+# Maintainer: Norbert Pfeiler <norbert.pfeiler@gmail.com>
+# Contributor: Andrew Sun <adsun701@gmail.com>
+
+_realname=snappy
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=1.1.7
+pkgrel=2
+pkgdesc="A fast C++ compressor/decompressor library (mingw-w64)"
+arch=('any')
+license=('New BSD License')
+url="https://github.com/google/snappy"
+depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
+makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-gcc"
+             "make")
+checkdepends=("${MINGW_PACKAGE_PREFIX}-zlib"
+              "${MINGW_PACKAGE_PREFIX}-lzo2")
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/google/snappy/archive/${pkgver}.tar.gz")
+sha256sums=('3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4')
+
+build() {
+  # Shared Build
+  [[ -d "${srcdir}"/build-${MINGW_CHOST}-shared ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}-shared
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-shared
+  cd ${srcdir}/build-${MINGW_CHOST}-shared
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON \
+      -DSNAPPY_BUILD_TESTS=OFF \
+      ../${_realname}-${pkgver}
+
+  make
+
+  # Static Build
+  [[ -d "${srcdir}"/build-${MINGW_CHOST}-static ]] && rm -rf "${srcdir}"/build-${MINGW_CHOST}-static
+  mkdir -p ${srcdir}/build-${MINGW_CHOST}-static
+  cd ${srcdir}/build-${MINGW_CHOST}-static
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+    ${MINGW_PREFIX}/bin/cmake \
+      -G'MSYS Makefiles' \
+      -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DSNAPPY_BUILD_TESTS=OFF \
+      ../${_realname}-${pkgver}
+
+  make
+}
+
+package() {
+  # Shared Install
+  cd "${srcdir}/build-${MINGW_CHOST}-shared"
+  make DESTDIR=${pkgdir} install
+
+  # Static Install
+  cd "${srcdir}/build-${MINGW_CHOST}-static"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
In preparation for the upcoming Arrow 0.14 release, on https://github.com/apache/arrow/pull/4622 I worked through building the arrow C++ library for R on Windows from the master branch of apache/arrow. (Aside: I'd like to review that CI setup with you; will follow up separately about that.) In the process, I sorted out a few config changes that were needed due to how the library has evolved in the couple of months since 0.13. 

While I got a passing build, I found that the Parquet support that gets built is in practice limited because the library is built [without snappy](https://github.com/apache/arrow/pull/4622/files#diff-621494f01eee471e820269600278bc45R80), which is commonly used to compress .parquet files. 

```
> f <- system.file("v0.7.1.parquet", package="arrow")
> library(arrow)
> arrow_available()
[1] TRUE
> df <- read_parquet(f)
Error in read_parquet_file(file) : 
  Arrow error: IOError: Arrow error: NotImplemented: Snappy codec support not built
```

I supposed that what was needed was to add snappy to this repository and then we could use that as a dependency in the arrow PKGBUILD, so that's what this PR does. [This change fails on Appveyor](https://ci.appveyor.com/project/nealrichardson/rtools-backports/builds/25428062/job/d81b1ipb713acnbl#L595) due to another dependency (gcc-libs). Perhaps that needs to be added too, but I'm just learning how all this fits together and figured you could advise whether I'm on the right track before I advanced too much further with trial and error.