### PR TITLE
add hdf5

### DIFF
--- a/mingw-w64-hdf5/PKGBUILD
+++ b/mingw-w64-hdf5/PKGBUILD
@@ -1,0 +1,93 @@
+# Maintainer: Alexey Pavlov <alexpux@gmail.com>
+# Contributor: Xin Sun <sun.simpson@gmail.com>
+
+_realname=hdf5
+pkgbase="mingw-w64-${_realname}"
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+_ver=1.10.5
+patch=
+pkgver=${_ver}${patch//-/.}
+pkgrel=9002
+pkgdesc="General purpose library and file format for storing scientific data (mingw-w64)"
+arch=('any')
+license=("custom")
+url="https://www.hdfgroup.org/HDF5/"
+source=("https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-${_ver%.*}/hdf5-${_ver}${patch}/src/hdf5-${_ver}${patch}.tar.bz2"
+        "hdf5-default-import-suffix.patch"
+        "hdf5-fix-install-docs.patch"
+        "hdf5-proper-library-names-mingw.patch"
+        "hdf5-fix-find-szip.patch"
+        "hdf5-cmake-size-type-checks.patch"
+        "utf8-windows-filenames.patch")
+sha256sums=('68d6ea8843d2a106ec6a7828564c1689c7a85714a35d8efafa2fee20ca366f44'
+            '81bd20b39ff5064cb454b7763b6cb9d3a2443c1fe0625f2d7819dce97b0b628d'
+            '72a4c3ff11b0811e2462252ddc7f14428c0241c71b3403408dbc0f93a21271c9'
+            '828e431c8982846c2c67763368b5ba3bf6a27cac7ed6bd8a73ed8bcbf3fba6a3'
+            '905c1ae3a28ace1557584bbdbd2e50b721fda0ccc9e816e77834655053d4410e'
+            '2efd623ea7b2c5c81dd8ae4aa37f480f475c0774b333a39834e4cb1fb70d8a24'
+            'ae5c8f45fbdd00e3f3e37de24dd34850fc48e736e801086a42eeda5a590bac1c')
+depends=("${MINGW_PACKAGE_PREFIX}-zlib")
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-gcc-fortran"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+             "patch")
+options=('staticlibs' 'strip')
+
+groups=("rtools-${_realname}")
+
+prepare() {
+  cd "${srcdir}/${_realname}-${_ver}${patch}"
+  patch -p1 -i "${srcdir}/hdf5-default-import-suffix.patch"
+  patch -p1 -i "${srcdir}/hdf5-fix-install-docs.patch"
+  patch -p1 -i "${srcdir}/hdf5-proper-library-names-mingw.patch"
+  patch -p1 -i "${srcdir}/hdf5-fix-find-szip.patch"
+  patch -p1 -i "${srcdir}/hdf5-cmake-size-type-checks.patch"
+  patch -p1 -i "${srcdir}/utf8-windows-filenames.patch"
+}
+
+build() {
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir -p ${srcdir}/build-${MINGW_CHOST} && cd ${srcdir}/build-${MINGW_CHOST}
+
+
+  export CC="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/gcc"
+  export CXX="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/g++"
+  export PATH="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin:$PATH"
+  export CPPFLAGS="-I${MINGW_PREFIX}/include"
+  export LIBS="-L${MINGW_PREFIX}/libs"  
+
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake.exe \
+    -Wno-dev \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_SKIP_RPATH=ON \
+    -DHDF5_BUILD_HL_LIB=ON \
+    -DHDF5_BUILD_CPP_LIB=ON \
+    -DHDF5_BUILD_FORTRAN=ON \
+    -DHDF5_BUILD_TOOLS=ON \
+    -DHDF5_ENABLE_DEPRECATED_SYMBOLS=ON \
+    -DHDF5_ENABLE_SZIP_SUPPORT=OFF \
+    -DHDF5_ENABLE_Z_LIB_SUPPORT=ON \
+    -DHDF5_INSTALL_CMAKE_DIR="lib/cmake" \
+    -DHDF5_INSTALL_DATA_DIR="share" \
+    ../${_realname}-${_ver}${patch}
+
+  make
+}
+
+package() {
+  mkdir ${srcdir}/build-${MINGW_CHOST}/bin/static/Release/
+  cp ${srcdir}/build-${MINGW_CHOST}/bin/static/*.mod ${srcdir}/build-${MINGW_CHOST}/bin/static/Release
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+
+  local PREFIX_WIN=$(cygpath -wm ${MINGW_PREFIX})
+  for _f in "${pkgdir}${MINGW_PREFIX}"/lib/cmake/hdf5/*.cmake; do
+    sed -e "s|${PREFIX_WIN}|\$\{_IMPORT_PREFIX\}|g" -i ${_f}
+  done
+}

--- a/mingw-w64-hdf5/hdf5-cmake-size-type-checks.patch
+++ b/mingw-w64-hdf5/hdf5-cmake-size-type-checks.patch
@@ -1,0 +1,30 @@
+diff -Naur hdf5-1.8.19.org/config/cmake_ext_mod/ConfigureChecks.cmake hdf5-1.8.19/config/cmake_ext_mod/ConfigureChecks.cmake
+--- hdf5-1.8.19.org/config/cmake_ext_mod/ConfigureChecks.cmake	2017-06-15 17:47:13.000000000 +0200
++++ hdf5-1.8.19/config/cmake_ext_mod/ConfigureChecks.cmake	2017-11-06 23:06:21.235526700 +0100
+@@ -405,7 +405,7 @@
+   if (NOT ${HDF_PREFIX}_SIZEOF_SSIZE_T)
+     set (${HDF_PREFIX}_SIZEOF_SSIZE_T 0)
+   endif ()
+-  if (NOT WINDOWS)
++  if (NOT MSVC)
+     HDF_CHECK_TYPE_SIZE (ptrdiff_t    ${HDF_PREFIX}_SIZEOF_PTRDIFF_T)
+   endif ()
+ endif ()
+@@ -429,7 +429,7 @@
+   HDF_CHECK_TYPE_SIZE (_Bool        ${HDF_PREFIX}_SIZEOF_BOOL)
+ endif ()
+ 
+-if (NOT WINDOWS)
++if (NOT MSVC)
+   #-----------------------------------------------------------------------------
+   # Check if the dev_t type is a scalar type
+   #-----------------------------------------------------------------------------
+@@ -561,7 +561,7 @@
+ #-----------------------------------------------------------------------------
+ # Check a bunch of other functions
+ #-----------------------------------------------------------------------------
+-if (NOT WINDOWS)
++if (NOT MSVC)
+   foreach (test
+       HAVE_ATTRIBUTE
+       HAVE_C99_FUNC

--- a/mingw-w64-hdf5/hdf5-default-import-suffix.patch
+++ b/mingw-w64-hdf5/hdf5-default-import-suffix.patch
@@ -1,0 +1,18 @@
+--- hdf5-1.8.19.orig/config/cmake_ext_mod/HDFMacros.cmake	2017-07-28 16:47:51.434642000 +0200
++++ hdf5-1.8.19/config/cmake_ext_mod/HDFMacros.cmake	2017-07-28 16:55:55.588824300 +0200
+@@ -126,15 +126,6 @@
+     endif ()
+   endif ()
+ 
+-  #----- Use MSVC Naming conventions for Shared Libraries
+-  if (MINGW AND ${libtype} MATCHES "SHARED")
+-    set_target_properties (${libtarget}
+-        PROPERTIES
+-        IMPORT_SUFFIX ".lib"
+-        IMPORT_PREFIX ""
+-        PREFIX ""
+-    )
+-  endif ()
+ endmacro ()
+ 
+ #-------------------------------------------------------------------------------

--- a/mingw-w64-hdf5/hdf5-fix-find-szip.patch
+++ b/mingw-w64-hdf5/hdf5-fix-find-szip.patch
@@ -1,0 +1,43 @@
+--- hdf5-1.8.19.orig/config/cmake_ext_mod/FindSZIP.cmake	2017-07-28 17:00:41.666213900 +0200
++++ hdf5-1.8.19/config/cmake_ext_mod/FindSZIP.cmake	2017-07-28 17:01:38.212923600 +0200
+@@ -100,7 +100,7 @@
+     NO_DEFAULT_PATH
+ )
+ 
+-if (WIN32)
++if (MSVC)
+     set (SZIP_SEARCH_DEBUG_NAMES "sz_d;libsz_d")
+     set (SZIP_SEARCH_RELEASE_NAMES "sz;libsz;libszip")
+ else ()
+--- hdf5-1.8.21/CMakeFilters.cmake.orig	2018-07-31 13:15:05.730704200 +0300
++++ hdf5-1.8.21/CMakeFilters.cmake	2018-07-31 13:21:23.985568600 +0300
+@@ -44,10 +44,10 @@
+       find_package (ZLIB NAMES ${ZLIB_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
+       if (NOT ZLIB_FOUND)
+         find_package (ZLIB) # Legacy find
+-        if (ZLIB_FOUND)
+-          set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
+-          set (LINK_COMP_SHARED_LIBS ${LINK_COMP_SHARED_LIBS} ${ZLIB_LIBRARIES})
+-        endif ()
++      endif ()
++      if (ZLIB_FOUND)
++        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${ZLIB_LIBRARIES})
++        set (LINK_COMP_SHARED_LIBS ${LINK_COMP_SHARED_LIBS} ${ZLIB_LIBRARIES})
+       endif ()
+     endif ()
+     if (ZLIB_FOUND)
+@@ -95,10 +95,10 @@
+     find_package (SZIP NAMES ${SZIP_PACKAGE_NAME}${HDF_PACKAGE_EXT} COMPONENTS static shared)
+     if (NOT SZIP_FOUND)
+       find_package (SZIP) # Legacy find
+-      if (SZIP_FOUND)
+-        set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
+-        set (LINK_COMP_SHARED_LIBS ${LINK_COMP_SHARED_LIBS} ${SZIP_LIBRARIES})
+-      endif ()
++    endif ()
++    if (SZIP_FOUND)
++      set (LINK_COMP_LIBS ${LINK_COMP_LIBS} ${SZIP_LIBRARIES})
++      set (LINK_COMP_SHARED_LIBS ${LINK_COMP_SHARED_LIBS} ${SZIP_LIBRARIES})
+     endif ()
+   endif ()
+   if (SZIP_FOUND)

--- a/mingw-w64-hdf5/hdf5-fix-install-docs.patch
+++ b/mingw-w64-hdf5/hdf5-fix-install-docs.patch
@@ -1,0 +1,20 @@
+--- hdf5-1.8.12/CMakeInstallation.cmake.orig	2013-11-21 19:14:04.000000000 +0400
++++ hdf5-1.8.12/CMakeInstallation.cmake	2014-04-30 12:23:14.248200000 +0400
+@@ -144,7 +144,7 @@
+   install (
+       FILES
+           ${HDF5_SOURCE_DIR}/COPYING
+-      DESTINATION ${HDF5_INSTALL_DATA_DIR}
++      DESTINATION ${HDF5_INSTALL_DATA_DIR}/doc/hdf5
+       COMPONENT hdfdocuments
+   )
+   if (EXISTS "${HDF5_SOURCE_DIR}/release_docs" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/release_docs")
+@@ -188,7 +188,7 @@
+     endif (HDF5_PACK_INSTALL_DOCS)
+     install (
+         FILES ${release_files}
+-        DESTINATION ${HDF5_INSTALL_DATA_DIR}
++        DESTINATION ${HDF5_INSTALL_DATA_DIR}/doc/hdf5
+         COMPONENT hdfdocuments
+     )
+   endif (EXISTS "${HDF5_SOURCE_DIR}/release_docs" AND IS_DIRECTORY "${HDF5_SOURCE_DIR}/release_docs")

--- a/mingw-w64-hdf5/hdf5-proper-library-names-mingw.patch
+++ b/mingw-w64-hdf5/hdf5-proper-library-names-mingw.patch
@@ -1,0 +1,37 @@
+--- hdf5-1.8.19.orig/config/cmake_ext_mod/HDFMacros.cmake	2017-07-28 16:41:41.840936100 +0200
++++ hdf5-1.8.19/config/cmake_ext_mod/HDFMacros.cmake	2017-07-28 16:45:12.960710400 +0200
+@@ -88,7 +88,10 @@
+ 
+ #-------------------------------------------------------------------------------
+ macro (HDF_SET_LIB_OPTIONS libtarget libname libtype)
+-  if (WIN32)
++  if (MINGW)
++    string(REGEX REPLACE "^lib([A-za-z]+)" "\\1" libname ${libname})
++  endif ()
++  if (MSVC)
+     set (LIB_DEBUG_SUFFIX "_D")
+   else ()
+     set (LIB_DEBUG_SUFFIX "_debug")
+@@ -97,7 +100,7 @@
+       set (LIB_DEBUG_NAME "${libname}_debug")
+     endif ()
+   else ()
+-    if (WIN32)
++    if (MSVC)
+       set (LIB_RELEASE_NAME "lib${libname}")
+       set (LIB_DEBUG_NAME "lib${libname}_D")
+     else ()
+@@ -116,6 +116,13 @@
+          OUTPUT_NAME_RELWITHDEBINFO
+                ${LIB_RELEASE_NAME}
+   )
++ 
++  if (MINGW)
++    set_target_properties (${libtarget} PROPERTIES OUTPUT_NAME ${libname} ARCHIVE_OUTPUT_NAME ${libname})
++    if (${libtype} MATCHES "SHARED")
++      set_target_properties (${libtarget} PROPERTIES RUNTIME_OUTPUT_NAME ${libname}-0)
++    endif ()
++  endif ()
+   if (${libtype} MATCHES "STATIC")
+     if (WIN32)
+       set_target_properties (${libtarget}

--- a/mingw-w64-hdf5/utf8-windows-filenames.patch
+++ b/mingw-w64-hdf5/utf8-windows-filenames.patch
@@ -1,0 +1,178 @@
+From dca776addb62897ab5956d0302a25ae3f8a0ae6d Mon Sep 17 00:00:00 2001
+From: Tom Schoonjans <Tom.Schoonjans@diamond.ac.uk>
+Date: Tue, 27 Feb 2018 15:46:36 +0000
+Subject: [PATCH 1/3] Fix implicit function declaration warning
+
+---
+ src/H5Dprivate.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/H5Dprivate.h b/src/H5Dprivate.h
+index ed13467883..4d2c4a1797 100644
+--- a/src/H5Dprivate.h
++++ b/src/H5Dprivate.h
+@@ -206,5 +206,6 @@ H5_DLL herr_t H5D_virtual_free_parsed_name(H5O_storage_virtual_name_seg_t *name_
+ H5_DLL herr_t H5D_btree_debug(H5F_t *f, hid_t dxpl_id, haddr_t addr, FILE * stream,
+     int indent, int fwidth, unsigned ndims, const uint32_t *dim);
+ 
++H5_DLL herr_t H5D__layout_set_version(H5F_t *f, H5O_layout_t *layout);
+ #endif /* _H5Dprivate_H */
+ 
+-- 
+2.15.1
+
+
+From 04a3ec7ee7a629c6e6309537faab83bfd76e13fe Mon Sep 17 00:00:00 2001
+From: Tom Schoonjans <Tom.Schoonjans@diamond.ac.uk>
+Date: Tue, 27 Feb 2018 15:49:30 +0000
+Subject: [PATCH 2/3] Restore MSYS/MINGW support
+
+---
+ src/H5system.c                  | 4 ++++
+ src/H5win32defs.h               | 7 ++++++-
+ test/testframe.c                | 7 +++++++
+ tools/test/h5repack/Makefile.am | 4 ++++
+ 4 files changed, 43 insertions(+), 1 deletion(-)
+
+diff --git a/src/H5system.c b/src/H5system.c
+index 719b7e0ad7..3ac5281ac6 100644
+--- a/src/H5system.c
++++ b/src/H5system.c
+@@ -799,6 +799,10 @@ Wgettimeofday(struct timeval *tv, struct timezone *tz)
+  *
+  *-------------------------------------------------------------------------
+  */
++#ifdef H5_HAVE_MINGW
++// definition of getenv_s is currently missing in MinGW, appears to be a bug
++_CRTIMP errno_t __cdecl getenv_s(size_t *pReturnValue, char *buffer, size_t numberOfElements, const char *varname);
++#endif
+ int
+ Wsetenv(const char *name, const char *value, int overwrite)
+ {
+diff --git a/src/H5win32defs.h b/src/H5win32defs.h
+index 45222280ba..82a2e93a44 100644
+--- a/src/H5win32defs.h
++++ b/src/H5win32defs.h
+@@ -54,7 +54,12 @@ typedef __int64             h5_stat_size_t;
+  * Also note that the variadic macro is using a VC++ extension
+  * where the comma is dropped if nothing is passed to the ellipsis.
+  */
+-#define HDopen(S,F,...)       _open(S, F | _O_BINARY, __VA_ARGS__)
++#ifdef H5_HAVE_MINGW
++  /* GCC/MINGW uses a different extension to handle unused ellipses */
++  #define HDopen(S,F,...)       _open(S, F | _O_BINARY, ##__VA_ARGS__)
++#else
++  #define HDopen(S,F,...)       _open(S, F | _O_BINARY, __VA_ARGS__)
++#endif
+ #define HDread(F,M,Z)       _read(F,M,Z)
+ #define HDrmdir(S)          _rmdir(S)
+ #define HDsetvbuf(F,S,M,Z)  setvbuf(F,S,M,(Z>1?Z:2))
+diff --git a/test/testframe.c b/test/testframe.c
+index 21f9ea3d94..56b232fcca 100644
+--- a/test/testframe.c
++++ b/test/testframe.c
+@@ -19,6 +19,13 @@
+  *
+  */
+ 
++
++#include "H5pubconf.h"
++#ifdef H5_HAVE_MINGW
++  #define _POSIX
++  #define __USE_MINGW_ALARM
++  #include <io.h>
++#endif
+ #include "testhdf5.h"
+ 
+ /*
+-- 
+2.15.1
+
+
+From e9762862abb255e68f40b62579892a1572fe9294 Mon Sep 17 00:00:00 2001
+From: Tom Schoonjans <Tom.Schoonjans@diamond.ac.uk>
+Date: Tue, 27 Feb 2018 16:49:02 +0000
+Subject: [PATCH 3/3] Windows: Add support for UTF8 encoded filenames
+
+This patch changes the way files will be created and opened on the
+Windows platform.
+
+Until now, filenames passed to functions such as H5Fcreate would work
+only if they were encoded in the current codepage. This would not work
+however, for example in the case when trying to open a filename
+containing japanese characters on a system with the italian codepage.
+
+A possible workaround would be through the use of GetShortPathName, but
+this function does not work on all filesystems.
+
+The only permanent solution involves the use of the wide character API,
+as recommended by Microsoft (codepages are actively discouraged). For
+this, the user needs to pass a Unicode UTF-8 filename to HDopen, which
+is then fed to _wopen, after performing the conversion of the filename
+to the corresponding wide character string (UTF-16).
+---
+ src/H5FDwindows.c | 22 +++++++++++++++++++++-
+ src/H5win32defs.h |  5 +++--
+ 2 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/src/H5FDwindows.c b/src/H5FDwindows.c
+index 76c4f18af3..501e307fd5 100644
+--- a/src/H5FDwindows.c
++++ b/src/H5FDwindows.c
+@@ -22,9 +22,29 @@
+ #include "H5MMprivate.h"    /* Memory management        */
+ #include "H5Pprivate.h"     /* Property lists           */
+ 
++#include <stdio.h>
++
+ #ifdef H5_HAVE_WINDOWS
+ 
+-
++int _open_utf8(const char *name, int oflag, ...)
++{
++    va_list args;
++    int fd = -1;
++    int name_len = MultiByteToWideChar(CP_UTF8, 0, name, -1, NULL, 0);
++    wchar_t* wname = malloc(sizeof(wchar_t)*(name_len + 1));
++    MultiByteToWideChar(CP_UTF8, 0, name, -1, wname, name_len + 1);
++    if (oflag & _O_CREAT) {
++        va_start(args, oflag);
++        fd = _wopen(wname, oflag, va_arg(args, int));
++        va_end(args);
++    }
++    else {
++        fd = _wopen(wname, oflag);
++    }
++    free(wname);
++    return fd;
++}
++
+ /*-------------------------------------------------------------------------
+  * Function:    H5Pset_fapl_windows
+  *
+diff --git a/src/H5win32defs.h b/src/H5win32defs.h
+index 82a2e93a44..f08cb283ef 100644
+--- a/src/H5win32defs.h
++++ b/src/H5win32defs.h
+@@ -56,9 +56,9 @@ typedef __int64             h5_stat_size_t;
+  */
+ #ifdef H5_HAVE_MINGW
+   /* GCC/MINGW uses a different extension to handle unused ellipses */
+-  #define HDopen(S,F,...)       _open(S, F | _O_BINARY, ##__VA_ARGS__)
++  #define HDopen(S,F,...)     _open_utf8(S, F | _O_BINARY, ##__VA_ARGS__)
+ #else
+-  #define HDopen(S,F,...)       _open(S, F | _O_BINARY, __VA_ARGS__)
++  #define HDopen(S,F,...)     _open_utf8(S, F | _O_BINARY, __VA_ARGS__)
+ #endif
+ #define HDread(F,M,Z)       _read(F,M,Z)
+ #define HDrmdir(S)          _rmdir(S)
+@@ -137,6 +137,7 @@ extern "C" {
+     H5_DLL long Wlroundf(float arg);
+     H5_DLL double Wround(double arg);
+     H5_DLL float Wroundf(float arg);
++    H5_DLL int _open_utf8(const char *name, int oflag, ...);
+ #ifdef __cplusplus
+ }
+ #endif /* __cplusplus */
+-- 
+2.15.1


### PR DESCRIPTION
We really only need the backport for the hdf5_cpp library, for the rest we can use the regular build.