### PR TITLE
Update arrow for 2.0.0

### DIFF
--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -22,9 +22,9 @@ options=("staticlibs" "strip" "!buildflags")
 # source_dir=${_realname}
 
 # Uncomment to build from rc
-source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc2/apache-arrow-${pkgver}.tar.gz")
+# source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc2/apache-arrow-${pkgver}.tar.gz")
 # This is the official release
-# source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
 source_dir="apache-${_realname}-${pkgver}"
 sha256sums=("be0342cc847bb340d86aeaef43596a0b6c1dbf1ede9c789a503d939e01c71fbe")
 

--- a/mingw-w64-arrow/PKGBUILD
+++ b/mingw-w64-arrow/PKGBUILD
@@ -2,7 +2,7 @@
 _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=1.0.1
+pkgver=2.0.0
 pkgrel=1
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=("any")
@@ -22,11 +22,11 @@ options=("staticlibs" "strip" "!buildflags")
 # source_dir=${_realname}
 
 # Uncomment to build from rc
-# source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc0/apache-arrow-${pkgver}.tar.gz")
+source=("${_realname}-${pkgver}.tar.gz"::"https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${pkgver}-rc2/apache-arrow-${pkgver}.tar.gz")
 # This is the official release
-source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
+# source=("${_realname}-${pkgver}.tar.gz"::"https://downloads.apache.org/arrow/arrow-${pkgver}/apache-arrow-${pkgver}.tar.gz")
 source_dir="apache-${_realname}-${pkgver}"
-sha256sums=("149ca6aa969ac5742f3b30d1f69a6931a533fd1db8b96712e60bf386a26dc75c")
+sha256sums=("be0342cc847bb340d86aeaef43596a0b6c1dbf1ede9c789a503d939e01c71fbe")
 
 pkgver() {
   cd "$source_dir"
@@ -63,14 +63,17 @@ build() {
     -DARROW_HDFS=OFF \
     -DARROW_JEMALLOC=OFF \
     -DARROW_JSON=ON \
-    -DARROW_MIMALLOC=OFF \
+    -DARROW_LZ4_USE_SHARED=OFF \
+    -DARROW_MIMALLOC=ON \
     -DARROW_PARQUET=ON \
+    -DARROW_SNAPPY_USE_SHARED=OFF \
     -DARROW_USE_GLOG=OFF \
     -DARROW_WITH_LZ4=ON \
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_UTF8PROC=OFF \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
+    -DARROW_ZSTD_USE_SHARED=OFF \
     -DCMAKE_BUILD_TYPE="release" \
     -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     -DCMAKE_UNITY_BUILD=ON \


### PR DESCRIPTION
cf. https://github.com/r-windows/rtools-packages/pull/160

Changes:

* Mimalloc enabled (the Vista compatibility patch has been released)
* Add some new USE_SHARED=OFF flags